### PR TITLE
Updated ip for use with rpi3b

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Join the chat at https://gitter.im/pirate-sh/ip](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pirate-sh/ip?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-  Usage: pirateship [options] [command]
+  Usage: node cli.js [options] [command]
 
 
   Commands:
@@ -9,10 +7,11 @@
     rename <hostname>                                         changes Hostname
     adapter <wirelessSSID> <password> <wirelessSecurityType>  [deprecated] connects a adapter to a wifi network
     wifi <ESSID> [password]                                   connects to a wifi network
-    ethernet <ip> <mask> <gateway> <dns>                      configures rpi network interface to a static ip address
+    swifi <ip> <mask> <gateway> <dns>                      configures rpi wifi interface to a static ip address
+
+    sethernet <ip> <mask> <gateway> <dns>                      configures rpi ethernet interface to a static ip address
     expandfs                                                  expands the partition of the RPI image to the maximum of the SDcard
     detectrpi                                                 detects the hardware version of a raspberry pi
-    detectwifi                                                detect chipset of USB-Wifi dongle
     *                                                         temporary catch all
 
   Options:
@@ -20,6 +19,7 @@
     -h, --help  output usage informatio)
 
   Installation:
+    So far this program assumes you can somehow manage to download nodejs 8 and also the npm packages commander and underscore, which are required for this program to run properly. 
     
     1. Install node 8
        > curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@
        > git clone https://github.com/snazzybunny/ip.git
        > cd ip
     3. Install npm packages called commander and underscore
-       > npm install commander
-       > npm install underscore
-    4. Test the program by changing hostname to ole
-       sudo node cli.js rename ole
-    5. Output should be like:
+       > sudo npm install commander
+       > sudo npm install underscore
+    4. Figure out hostname of rpi. Output should print raspberrypi by default.
+       > hostname
+    5. Test the program by changing hostname to ole.
+       > sudo node cli.js rename ole
+    6. Output should be like:
        > pi@raspberrypi:~/ip $ cat /etc/hostname
        > ole

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     wifi <ESSID> [password]                                   connects to a wifi network
     swifi <ip> <mask> <gateway> <dns>                      configures rpi wifi interface to a static ip address
 
-    sethernet <ip> <mask> <gateway> <dns>                      configures rpi ethernet interface to a static ip address
+    ethernet <ip> <mask> <gateway> <dns>                      configures rpi network interface to a static ip address
     expandfs                                                  expands the partition of the RPI image to the maximum of the SDcard
     detectrpi                                                 detects the hardware version of a raspberry pi
     *                                                         temporary catch all
@@ -37,3 +37,14 @@
     6. Output should be like:
        > pi@raspberrypi:~/ip $ cat /etc/hostname
        > ole
+
+  Additional Notes:
+
+       wifi - ESSID is the SSID or the network name of your wireless network and password is the password for the corresponding network.
+
+       rename - The hostname is a label assigned to the RPI device for identification on a network and is useful for communication amongst different devices. The default hostname is raspberrypi.
+
+       ethernet and swifi  - before using these command, I checked that my network follows the ip range from 192.168.0.1 to 192.168.0.254.
+       To change my ip address to 192.168.0.251, I can issue the command below given that my router is found at 192.168.0.1 and 
+       that it is also a dns server. Alternatively, you can use Google's dns server, which is 8.8.8.8 or 8.8.4.4.  
+       > ethernet 192.168.0.251 255.255.255.0 192.168.0.1 192.168.0.1 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@
     1. Install node 8
        > curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
        > sudo apt-get install -y nodejs
-    2. Install npm packages called commander and underscore
+    2. Clone this repo then cd into ip directory
+       > git clone https://github.com/snazzybunny/ip.git
+       > cd ip
+    3. Install npm packages called commander and underscore
        > npm install commander
        > npm install underscore
-    3. Test the program by changing hostname to ole
+    4. Test the program by changing hostname to ole
        sudo node cli.js rename ole
-    4. Output should be like:
+    5. Output should be like:
        > pi@raspberrypi:~/ip $ cat /etc/hostname
        > ole

--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@
     1. Install node 8
        > curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
        > sudo apt-get install -y nodejs
-    2. Clone this repo then cd into ip directory
+    2. Clone this repo then cd into ip directory to install the npm packages
        > git clone https://github.com/snazzybunny/ip.git
        > cd ip
     3. Install npm packages called commander and underscore
+       > sudo npm install
+
+       or manually install each one    
+
        > sudo npm install commander
        > sudo npm install underscore
     4. Figure out hostname of rpi. Output should print raspberrypi by default.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,15 @@
 
   Additional Notes:
 
-       wifi - ESSID is the SSID or the network name of your wireless network and password is the password for the corresponding network.
+    wifi - ESSID is the SSID or the network name of your wireless network and password is the password 
+           for the corresponding network.
 
-       rename - The hostname is a label assigned to the RPI device for identification on a network and is useful for communication amongst different devices. The default hostname is raspberrypi.
+    rename - The hostname is a label assigned to the RPI device for identification on a network and 
+             is useful for communication amongst different devices. The default hostname is raspberrypi.
 
-       ethernet and swifi  - before using these command, I checked that my network follows the ip range from 192.168.0.1 to 192.168.0.254.
-       To change my ip address to 192.168.0.251, I can issue the command below given that my router is found at 192.168.0.1 and 
-       that it is also a dns server. Alternatively, you can use Google's dns server, which is 8.8.8.8 or 8.8.4.4.  
-       > ethernet 192.168.0.251 255.255.255.0 192.168.0.1 192.168.0.1 
+    ethernet and swifi - before using these command, I checked that my network follows the ip range from 
+                         192.168.0.1 to 192.168.0.254. To change my ip address to 192.168.0.251, I can 
+                         issue the command below given that my router is found at 192.168.0.1 and 
+                         that it is also a dns server. Alternatively, you can use Google's dns server, 
+                         which is 8.8.8.8 or 8.8.4.4.  
+                           > ethernet 192.168.0.251 255.255.255.0 192.168.0.1 192.168.0.1 

--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@
   Options:
 
     -h, --help  output usage informatio)
+
+  Installation:
+    
+    1. Install node 8
+       > curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+       > sudo apt-get install -y nodejs
+    2. Install npm packages called commander and underscore
+       > npm install commander
+       > npm install underscore
+    3. Test the program by changing hostname to ole
+       sudo node cli.js rename ole
+    4. Output should be like:
+       > pi@raspberrypi:~/ip $ cat /etc/hostname
+       > ole

--- a/cli.js
+++ b/cli.js
@@ -36,12 +36,18 @@ program
   .description('connects to a wifi network')
   .action(wifi)
 
-var ethernet = require('./lib/ConfigureEthernet.js')
+var swifi = require('./lib/ConfigureWifiStatic.js')
+program
+  .command('swifi <ip> <mask> <gateway> <dns>')
+  .description('configures rpi wifi interface to a static ip address')
+  .action(swifi)
+
+var sethernet = require('./lib/ConfigureEthernet.js')
 
 program
-  .command('ethernet <ip> <mask> <gateway> <dns>')
-  .description('configures rpi network interface to a static ip address')
-  .action(ethernet)
+  .command('sethernet <ip> <mask> <gateway> <dns>')
+  .description('configures rpi ethernet interface to a static ip address')
+  .action(sethernet)
 
 var expandfs = require('./lib/ExpandFS.js')
 

--- a/cli.js
+++ b/cli.js
@@ -63,18 +63,18 @@ program
   .description('detects the hardware version of a raspberry pi')
   .action(detectrpi)
 
-var detectwifi = require('./lib/DetectWifi.js')
+// var detectwifi = require('./lib/DetectWifi.js')
 
-program
-  .command('detectwifi')
-  .description('detect chipset of USB-Wifi dongle')
-  .action(detectwifi)
+// program
+//  .command('detectwifi')
+//  .description('detect chipset of USB-Wifi dongle')
+//  .action(detectwifi)
 
 program
   .command('*')
   .description('temporary catch all')
   .action(function(env){
-    console.log('ERROR "%s" does not exsist\npirateship --help', env);});
+    console.log('ERROR "%s" does not exist\npirateship --help', env);});
 
 if (process.argv.length == 2) {
   process.argv.push('--help')

--- a/cli.js
+++ b/cli.js
@@ -42,12 +42,12 @@ program
   .description('configures rpi wifi interface to a static ip address')
   .action(swifi)
 
-var sethernet = require('./lib/ConfigureEthernet.js')
+var ethernet = require('./lib/ConfigureEthernet.js')
 
 program
-  .command('sethernet <ip> <mask> <gateway> <dns>')
-  .description('configures rpi ethernet interface to a static ip address')
-  .action(sethernet)
+  .command('ethernet <ip> <mask> <gateway> <dns>')
+  .description('configures rpi network interface to a static ip address')
+  .action(ethernet)
 
 var expandfs = require('./lib/ExpandFS.js')
 

--- a/lib/ConfigureEthernet.js
+++ b/lib/ConfigureEthernet.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var fs = require('fs')
 function puts(error, stdout, stderr) { sys.puts(stdout) } 

--- a/lib/ConfigureWifiStatic.js
+++ b/lib/ConfigureWifiStatic.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var sys = require('util')
+var exec = require('child_process').exec;
+var fs = require('fs')
+function puts(error, stdout, stderr) { sys.puts(stdout) } 
+
+function ifdownup(error, stdout, stderr) {
+  exec('ifdown wlan0', function(error, stdout, stderr) {
+    if (error !== null) {
+      console.log('exec error: ' + error);
+    }
+    exec('ifup wlan0', function(error, stdout, stderr) {
+      if (error !== null) {
+        console.log('exec error: ' + error);
+      }
+    })
+  })
+}
+
+module.exports = function(ip, mask, gateway, dns) {
+  var fileName = __dirname + '/interfaces.wlan0.template'
+  fs.readFile(fileName, 'utf8', function (err,data) {
+    if (err) return console.log(err)
+    var result = data.replace("IPADDRESS",ip).replace("NETMASK",mask).replace("GATEWAY",gateway).replace("DNS",dns)
+    var fileName = '/etc/network/interfaces'
+    fs.writeFile(fileName, result, 'utf8', function (err) {
+      if (err) return console.log(err)
+      ifdownup()
+      return console.log('This pirateship has anchored successfully!') 
+    })
+  })
+}
+
+

--- a/lib/Default.js
+++ b/lib/Default.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var _ = require('underscore')
 var program = require('commander');

--- a/lib/DetectRPI.js
+++ b/lib/DetectRPI.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var _ = require('underscore')
 var program = require('commander');

--- a/lib/DetectRPI.js
+++ b/lib/DetectRPI.js
@@ -16,15 +16,40 @@ function puts(error, stdout, stderr) { sys.puts(stdout) }
 module.exports = function() {
   cmd = "cat /proc/cpuinfo | grep Revision | sed 's/.* //g' | tr -d '\n'; "
 
+// List of revisions from http://elinux.org/RPi_HardwareHistory. ARPI should match one of the revision codes found from this link.
   var list = {
+    "Beta" : "BETA",
+    "0002" : "RPIB",
+    "0003" : "RPIB",
+    "0004" : "RPIB",
+    "0005" : "RPIB",
+    "0006" : "RPIB",
+    "0007" : "RPIA",
+    "0008" : "RPIA",
+    "0009" : "RPIA",
     "000d" : "RPIB",
     "000e" : "RPIB",
     "000f" : "RPIB",
     "0010" : "RPIB+",
     "0011" : "CM",
-    "a11041" : "RPI2B",
+    "0012" : "RPIA+",
+    "0013" : "RPIB+"
+    "0014" : "CM",
+    "0015" : "RPIA+",
+    "a01040" : "RPI2B",
+    "a01041" : "RPI2B",
     "a21041" : "RPI2B",
-    "a02082" : "RPI3B"
+    "a22042" : "RPI2B",
+    "900021" : "RPIA+",
+    "900032" : "RPIB+",
+    "900092" : "RPIZ",
+    "900093" : "RPIZ",
+    "920093" : "RPIZ",
+    "9000c1" : "RPIZW",
+    "a02082" : "RPI3B",
+    "a020a0" : "CM3",
+    "a22082" : "RPI3B",
+    "a32082" : "RPI3B"
   }
   exec(cmd, function(error, stdout, stderr) {
     if (error) return console.log('execerror')

--- a/lib/DetectRPI.js
+++ b/lib/DetectRPI.js
@@ -24,7 +24,7 @@ module.exports = function() {
     "0011" : "CM",
     "a11041" : "RPI2B",
     "a21041" : "RPI2B",
-    "a21041" : "RPI3B"
+    "a02082" : "RPI3B"
   }
   exec(cmd, function(error, stdout, stderr) {
     if (error) return console.log('execerror')

--- a/lib/DetectRPI.js
+++ b/lib/DetectRPI.js
@@ -33,7 +33,7 @@ module.exports = function() {
     "0010" : "RPIB+",
     "0011" : "CM",
     "0012" : "RPIA+",
-    "0013" : "RPIB+"
+    "0013" : "RPIB+",
     "0014" : "CM",
     "0015" : "RPIA+",
     "a01040" : "RPI2B",

--- a/lib/DetectRPI.js
+++ b/lib/DetectRPI.js
@@ -23,7 +23,8 @@ module.exports = function() {
     "0010" : "RPIB+",
     "0011" : "CM",
     "a11041" : "RPI2B",
-    "a21041" : "RPI2B"
+    "a21041" : "RPI2B",
+    "a21041" : "RPI3B"
   }
   exec(cmd, function(error, stdout, stderr) {
     if (error) return console.log('execerror')

--- a/lib/DetectWifi.js
+++ b/lib/DetectWifi.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var _ = require('underscore')
 var program = require('commander');

--- a/lib/DetectWifi.js
+++ b/lib/DetectWifi.js
@@ -25,7 +25,6 @@ module.exports = function() {
     "a11041" : "RPI2B",
     "a21041" : "RPI2B",
     "a02082" : "RPI3B"
-
   }
   exec(cmd, function(error, stdout, stderr) {
     if (error) return console.log('execerror')

--- a/lib/DetectWifi.js
+++ b/lib/DetectWifi.js
@@ -23,7 +23,9 @@ module.exports = function() {
     "0010" : "RPIB+",
     "0011" : "CM",
     "a11041" : "RPI2B",
-    "a21041" : "RPI2B"
+    "a21041" : "RPI2B",
+    "a02082" : "RPI3B"
+
   }
   exec(cmd, function(error, stdout, stderr) {
     if (error) return console.log('execerror')

--- a/lib/ExpandFS.js
+++ b/lib/ExpandFS.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var _ = require('underscore')
 var program = require('commander');

--- a/lib/ReconfigureHostname.js
+++ b/lib/ReconfigureHostname.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var _ = require('underscore')
 var program = require('commander');

--- a/lib/ReconfigureNetwork.js
+++ b/lib/ReconfigureNetwork.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var program = require('commander');
 var fs = require('fs')

--- a/lib/ReconfigureWifi.js
+++ b/lib/ReconfigureWifi.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var sys = require('sys')
+var sys = require('util')
 var exec = require('child_process').exec;
 var program = require('commander');
 var fs = require('fs')

--- a/lib/expandfs.sh
+++ b/lib/expandfs.sh
@@ -87,5 +87,6 @@ case "$1" in
 esac
 EOF
 
+#sudo resize2fs /dev/mmcblk0p2
 chmod +x /etc/init.d/resize2fs_once &&
 update-rc.d resize2fs_once defaults

--- a/lib/expandfs.sh
+++ b/lib/expandfs.sh
@@ -1,14 +1,30 @@
 #!/bin/sh
+get_init_sys() {
+  if command -v systemctl > /dev/null && systemctl | grep -q '\-\.mount'; then
+    SYSTEMD=1
+  elif [ -f /etc/init.d/cron ] && [ ! -h /etc/init.d/cron ]; then
+    SYSTEMD=0
+  else
+    echo "Unrecognised init system"
+    return 1
+  fi
+}
 
-if ! [ -h /dev/root ]; then
-  return 0
+get_init_sys
+if [ $SYSTEMD -eq 1 ]; then
+  ROOT_PART=$(mount | sed -n 's|^/dev/\(.*\) on / .*|\1|p')
+else
+  if ! [ -h /dev/root ]; then
+    return 0
+  fi
+  ROOT_PART=$(readlink /dev/root)
 fi
 
-ROOT_PART=$(readlink /dev/root)
-PART_NUM=${ROOT_PART#mmcblk0p}
 if [ "$PART_NUM" = "$ROOT_PART" ]; then
   return 0
 fi
+
+PART_NUM=${ROOT_PART#mmcblk0p}
 
 # NOTE: the NOOBS partition layout confuses parted. For now, let's only 
 # agree to work with a sufficiently simple partition layout
@@ -23,8 +39,9 @@ if [ "$LAST_PART_NUM" != "$PART_NUM" ]; then
 fi
 
 # Get the starting offset of the root partition
-PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d:)
+PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^${PART_NUM}" | cut -f 2 -d: | sed 's/[^0-9]//g')
 [ "$PART_START" ] || return 1
+
 # Return value will likely be error for fdisk as it fails to reload the
 # partition table because the root fs is mounted
 fdisk /dev/mmcblk0 <<EOF

--- a/lib/interfaces.wlan0.template
+++ b/lib/interfaces.wlan0.template
@@ -1,0 +1,14 @@
+auto lo
+
+iface lo inet loopback
+iface eth0 inet dhcp
+
+allow-hotplug wlan0
+iface wlan0 inet manual
+wpa-roam /etc/wpa_supplicant/wpa_supplicant.conf
+iface default inet static
+  address IPADDRESS
+  netmask NETMASK
+  gateway GATEWAY
+  dns-nameservers DNS
+

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "pirateship": "cli.js"
   },
   "dependencies": {
-        "commander": "^2.3.0",
-        "underscore": "^1.8.3"
+    "commander": "^2.9.0",
+    "underscore": "^1.8.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instructions on how to install are found in README.md. It would be a good idea to find a way to include the npm plugins like commander and underscore as well as nodejs v8 into the image, that is, if we were to use this program. Otherwise, you would need Internet before being able to use this program.

Tested on rpi3:
default, detectrpi, swifi, wifi, rename

Needs work on rpi3:
ethernet, expandfs

